### PR TITLE
Improving the way numeric values are dealt with and fixing failing tests

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -20,3 +20,8 @@
 * Allow to pass a custom HttpClient to customize things like proxy
 * Fixes in the cache logic
 
+### New in 1.1.1 (Release 2015/03/27)
+* Changed the way numeric values are handled when converting to fragments to allow for specific culture parsing
+* Added GetDecimal method to return Decimal fragment which is better suited to handle currencies instead of Double
+* Fixed some failing tests on non en-US culture
+

--- a/src/prismic.tests/DocTest.cs
+++ b/src/prismic.tests/DocTest.cs
@@ -147,7 +147,7 @@ namespace prismic.tests
 			var inRange = Predicates.inRange("my.product.price", 10, 20);
 
 			// Accessing number fields
-			double price = doc.GetNumber("product.price").Value;
+			double price = doc.GetNumber("product.price", new CultureInfo("en-US")).Value;
 			// endgist
 			Assert.AreEqual(price, 2.5);
 		}
@@ -161,15 +161,9 @@ namespace prismic.tests
                 .Query(@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbO"")]]")
                 .Submit();
             var doc = response.Results[0];
-            // startgist:57e8cda4c83cadf7f7d0:prismic-getNumber.cs
-            // Number predicates
-            var gt = Predicates.gt("my.product.price", 10);
-            var lt = Predicates.lt("my.product.price", 20);
-            var inRange = Predicates.inRange("my.product.price", 10, 20);
-
-            // Accessing number fields
+            
             decimal price = doc.GetDecimal("product.price", new CultureInfo("en-US")).Value;
-            // endgist
+            
             Assert.AreEqual(price, 2.5);
         }
 
@@ -303,7 +297,7 @@ namespace prismic.tests
 
 			// Accessing GeoPoint fragments
 			fragments.GeoPoint place = document.GetGeoPoint("article.location");
-			var coordinates = place.Latitude + "," + place.Longitude;
+            var coordinates = place.Latitude.ToString(new CultureInfo("en-US")) + "," + place.Longitude.ToString(new CultureInfo("en-US"));
 			// endgist
 			Assert.AreEqual(coordinates, "48.877108,2.333879");
 		}

--- a/src/prismic.tests/DocTest.cs
+++ b/src/prismic.tests/DocTest.cs
@@ -3,6 +3,7 @@ using prismic;
 using System;
 using System.Linq;
 using System.ComponentModel;
+using System.Globalization;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
@@ -150,6 +151,27 @@ namespace prismic.tests
 			// endgist
 			Assert.AreEqual(price, 2.5);
 		}
+
+        [Test()]
+        public async Task GetDecimalTest()
+        {
+            Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            var response = await api.Form("everything")
+                .Ref(api.Master)
+                .Query(@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbO"")]]")
+                .Submit();
+            var doc = response.Results[0];
+            // startgist:57e8cda4c83cadf7f7d0:prismic-getNumber.cs
+            // Number predicates
+            var gt = Predicates.gt("my.product.price", 10);
+            var lt = Predicates.lt("my.product.price", 20);
+            var inRange = Predicates.inRange("my.product.price", 10, 20);
+
+            // Accessing number fields
+            decimal price = doc.GetDecimal("product.price", new CultureInfo("en-US")).Value;
+            // endgist
+            Assert.AreEqual(price, 2.5);
+        }
 
 		[Test ()]
 		public async Task ImagesTest()

--- a/src/prismic.tests/DocTest.cs
+++ b/src/prismic.tests/DocTest.cs
@@ -128,7 +128,7 @@ namespace prismic.tests
 			// startgist:7869828eaa8c1b8555d3:prismic-getText.cs
 			var author = doc.GetText("blog-post.author");
 			// endgist
-			Assert.AreEqual(author, "John M. Martelle, Fine Pastry Magazine"); // gisthide
+			Assert.AreEqual("John M. Martelle, Fine Pastry Magazine", author); // gisthide
 		}
 
 		[Test ()]
@@ -149,7 +149,7 @@ namespace prismic.tests
 			// Accessing number fields
 			double price = doc.GetNumber("product.price", new CultureInfo("en-US")).Value;
 			// endgist
-			Assert.AreEqual(price, 2.5);
+            Assert.AreEqual(2.5, price);
 		}
 
         [Test()]
@@ -163,8 +163,8 @@ namespace prismic.tests
             var doc = response.Results[0];
             
             decimal price = doc.GetDecimal("product.price", new CultureInfo("en-US")).Value;
-            
-            Assert.AreEqual(price, 2.5);
+
+            Assert.AreEqual(2.5, price);
         }
 
 		[Test ()]
@@ -181,7 +181,7 @@ namespace prismic.tests
 			fragments.Image.View imageView = doc.GetImageView("product.image", "main");
 			String url = imageView.Url;
 			// endgist
-			Assert.AreEqual(url, "https://lesbonneschoses.cdn.prismic.io/lesbonneschoses/f606ad513fcc2a73b909817119b84d6fd0d61a6d.png");
+            Assert.AreEqual("https://lesbonneschoses.cdn.prismic.io/lesbonneschoses/f606ad513fcc2a73b909817119b84d6fd0d61a6d.png", url);
 		}
 
 		[Test ()]
@@ -221,7 +221,7 @@ namespace prismic.tests
 				int updateHour = updateTime.Value.Hour;
 			}
 			// endgist
-			Assert.AreEqual(dateYear, 2013);
+            Assert.AreEqual(2013, dateYear);
 		}
 
 		[Test ()]
@@ -244,7 +244,7 @@ namespace prismic.tests
 			}
 			// endgist
 			var firstDesc = group.GroupDocs [0].GetStructuredText ("desc");
-			Assert.AreEqual(firstDesc.AsHtml(resolver), "<p>A detailed step by step point of view on how installing happens.</p>");
+            Assert.AreEqual("<p>A detailed step by step point of view on how installing happens.</p>", firstDesc.AsHtml(resolver));
 		}
 
 		[Test ()]
@@ -299,7 +299,7 @@ namespace prismic.tests
 			fragments.GeoPoint place = document.GetGeoPoint("article.location");
             var coordinates = place.Latitude.ToString(new CultureInfo("en-US")) + "," + place.Longitude.ToString(new CultureInfo("en-US"));
 			// endgist
-			Assert.AreEqual(coordinates, "48.877108,2.333879");
+            Assert.AreEqual("48.877108,2.333879", coordinates);
 		}
 
 		[Test ()]

--- a/src/prismic/Fragment.cs
+++ b/src/prismic/Fragment.cs
@@ -51,9 +51,9 @@ namespace prismic
 				return new Number (Double.Parse ((string)json));
 			}
 
-            public static Number Parse(string json)
+            public static Number Parse(string json, IFormatProvider format)
             {
-                return new Number(Double.Parse(json));
+                return new Number(Double.Parse(json, format));
             }
 		}
 

--- a/src/prismic/Fragment.cs
+++ b/src/prismic/Fragment.cs
@@ -50,7 +50,37 @@ namespace prismic
 			public static Number Parse(JToken json) {
 				return new Number (Double.Parse ((string)json));
 			}
+
+            public static Number Parse(string json)
+            {
+                return new Number(Double.Parse(json));
+            }
 		}
+
+        public class Decimal : Fragment
+        {
+            private readonly decimal value;
+            public decimal Value
+            {
+                get
+                {
+                    return value;
+                }
+            }
+            public Decimal(decimal value)
+            {
+                this.value = value;
+            }
+            public String AsHtml()
+            {
+                return ("<span class=\"number\">" + value + "</span>");
+            }
+            public static Decimal Parse(string value, IFormatProvider provider)
+            {
+                var v = Convert.ToDecimal(value, provider);
+                return new Decimal(v);
+            }
+        }
 
 		public class Image: Fragment {
 
@@ -591,7 +621,7 @@ namespace prismic
 				case "Timestamp":
 					return Timestamp.Parse (json);
 				case "Number":
-					return Number.Parse (json);
+					return Text.Parse (json);
 				case "Color":
 					return Color.Parse (json);
 				case "Embed":

--- a/src/prismic/Predicates.cs
+++ b/src/prismic/Predicates.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Web.Routing;
 
 namespace prismic
 {
@@ -60,7 +62,11 @@ namespace prismic
 			} else if (value is System.DayOfWeek) {
 				return ("\"" + capitalize(((System.DayOfWeek) value).ToString()) + "\"");
 			} else if (value is DateTime) {
-				return (((DateTime) value) - new DateTime(1970, 1, 1)).TotalMilliseconds.ToString();
+				return (((DateTime) value) - new DateTime(1970, 1, 1)).TotalMilliseconds.ToString(new CultureInfo("en-US"));
+            } else if (value is Double) {
+				return ((double)value).ToString(new CultureInfo("en-US"));
+            } else if (value is Decimal) {
+				return ((decimal)value).ToString(new CultureInfo("en-US"));
 			} else {
 				return value.ToString();
 			}

--- a/src/prismic/WithFragments.cs
+++ b/src/prismic/WithFragments.cs
@@ -71,12 +71,16 @@ namespace prismic
             return null;
 		}
 
-		public fragments.Number GetNumber(String field) {
-			var frag = Get (field) as Text;
-		    return Number.Parse(frag.Value);
+        public fragments.Number GetNumber(String field, IFormatProvider format = null)
+        {
+            if (format == null)
+                format = Thread.CurrentThread.CurrentCulture;
+            
+            var frag = Get (field) as Text;
+		    return Number.Parse(frag.Value, format);
 		}
 
-        public fragments.Decimal GetDecimal(String field, IFormatProvider format)
+        public fragments.Decimal GetDecimal(String field, IFormatProvider format = null)
         {
             if (format == null)
                 format = Thread.CurrentThread.CurrentCulture;

--- a/src/prismic/WithFragments.cs
+++ b/src/prismic/WithFragments.cs
@@ -3,7 +3,10 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
 using prismic.fragments;
+using Decimal = prismic.fragments.Decimal;
 
 namespace prismic
 {
@@ -46,16 +49,16 @@ namespace prismic
 
 		public String GetText(String field) {
 			Fragment frag = Get (field);
-			if (frag is fragments.Text) {
+			
+            if (frag is fragments.Text) {
 				return ((fragments.Text)frag).Value;
 			}
-			if (frag is fragments.Number) {
-				return ((fragments.Number)frag).Value.ToString ();
-			}
-			if (frag is fragments.Color) {
+			
+            if (frag is fragments.Color) {
 				return ((fragments.Color)frag).Hex;
 			}
-			if (frag is fragments.StructuredText) {
+			
+            if (frag is fragments.StructuredText) {
 				var result = "";
 				foreach (fragments.StructuredText.Block block in ((fragments.StructuredText)frag).Blocks) {
 					if (block is fragments.StructuredText.TextBlock) {
@@ -64,16 +67,23 @@ namespace prismic
 				}
 				return result;
 			}
-			if (frag is fragments.Number) {
-				return ((fragments.Number)frag).Value.ToString ();
-			}
-			return null;
+			
+            return null;
 		}
 
 		public fragments.Number GetNumber(String field) {
-			Fragment frag = Get (field);
-			return frag is fragments.Number ? (fragments.Number)frag : null;
+			var frag = Get (field) as Text;
+		    return Number.Parse(frag.Value);
 		}
+
+        public fragments.Decimal GetDecimal(String field, IFormatProvider format)
+        {
+            if (format == null)
+                format = Thread.CurrentThread.CurrentCulture;
+            
+            var frag = Get(field) as Text;
+            return Decimal.Parse(frag.Value, format);
+        }
 
 		public fragments.Image.View GetImageView(String field, String view) {
 			var image = GetImage (field);


### PR DESCRIPTION
Hi, 

I changed the way numeric values are dealt with when retrieving and parsing data from prismic API calls.

Number fragment was being converted as soon as the value came in using the current thread culture, so whenever the main thread of the application was not in a culture ta uses . (dot) as the decimal separator the numeric value became conversion was wrong. Example: when the main thread of the application is running on pt-BR 78.50 becomes 7850,00 which is wrong.

In order to fix it the original value is stored inside the fragment as text and it is converted only when the caller calls GetNumber. Now it is also possible to specify the culture (IFormatProvider) when getting the specific fragment.

I also added a new GetDecimal method to return a decimal instead of double because decimals are better suited for currency instead of doubles.

I also fixed 4 tests that were failing because they were built on the premise that tests are always ran on en-US machines which is not the case for many people.