### PR TITLE
Improving the way numeric values are handled and fixing failing tests

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -20,3 +20,8 @@
 * Allow to pass a custom HttpClient to customize things like proxy
 * Fixes in the cache logic
 
+### New in 1.1.1 (Release 2015/03/27)
+* Changed the way numeric values are handled when converting to fragments to allow for specific culture parsing
+* Added GetDecimal method to return Decimal fragment which is better suited to handle currencies instead of Double
+* Fixed some failing tests on non en-US culture
+

--- a/src/prismic.tests/DocTest.cs
+++ b/src/prismic.tests/DocTest.cs
@@ -147,7 +147,7 @@ namespace prismic.tests
 			var inRange = Predicates.inRange("my.product.price", 10, 20);
 
 			// Accessing number fields
-			double price = doc.GetNumber("product.price").Value;
+			double price = doc.GetNumber("product.price", new CultureInfo("en-US")).Value;
 			// endgist
 			Assert.AreEqual(price, 2.5);
 		}
@@ -161,15 +161,9 @@ namespace prismic.tests
                 .Query(@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbO"")]]")
                 .Submit();
             var doc = response.Results[0];
-            // startgist:57e8cda4c83cadf7f7d0:prismic-getNumber.cs
-            // Number predicates
-            var gt = Predicates.gt("my.product.price", 10);
-            var lt = Predicates.lt("my.product.price", 20);
-            var inRange = Predicates.inRange("my.product.price", 10, 20);
-
-            // Accessing number fields
+            
             decimal price = doc.GetDecimal("product.price", new CultureInfo("en-US")).Value;
-            // endgist
+            
             Assert.AreEqual(price, 2.5);
         }
 
@@ -303,7 +297,7 @@ namespace prismic.tests
 
 			// Accessing GeoPoint fragments
 			fragments.GeoPoint place = document.GetGeoPoint("article.location");
-			var coordinates = place.Latitude + "," + place.Longitude;
+            var coordinates = place.Latitude.ToString(new CultureInfo("en-US")) + "," + place.Longitude.ToString(new CultureInfo("en-US"));
 			// endgist
 			Assert.AreEqual(coordinates, "48.877108,2.333879");
 		}

--- a/src/prismic.tests/DocTest.cs
+++ b/src/prismic.tests/DocTest.cs
@@ -3,6 +3,7 @@ using prismic;
 using System;
 using System.Linq;
 using System.ComponentModel;
+using System.Globalization;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
@@ -150,6 +151,27 @@ namespace prismic.tests
 			// endgist
 			Assert.AreEqual(price, 2.5);
 		}
+
+        [Test()]
+        public async Task GetDecimalTest()
+        {
+            Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            var response = await api.Form("everything")
+                .Ref(api.Master)
+                .Query(@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbO"")]]")
+                .Submit();
+            var doc = response.Results[0];
+            // startgist:57e8cda4c83cadf7f7d0:prismic-getNumber.cs
+            // Number predicates
+            var gt = Predicates.gt("my.product.price", 10);
+            var lt = Predicates.lt("my.product.price", 20);
+            var inRange = Predicates.inRange("my.product.price", 10, 20);
+
+            // Accessing number fields
+            decimal price = doc.GetDecimal("product.price", new CultureInfo("en-US")).Value;
+            // endgist
+            Assert.AreEqual(price, 2.5);
+        }
 
 		[Test ()]
 		public async Task ImagesTest()

--- a/src/prismic.tests/DocTest.cs
+++ b/src/prismic.tests/DocTest.cs
@@ -128,7 +128,7 @@ namespace prismic.tests
 			// startgist:7869828eaa8c1b8555d3:prismic-getText.cs
 			var author = doc.GetText("blog-post.author");
 			// endgist
-			Assert.AreEqual(author, "John M. Martelle, Fine Pastry Magazine"); // gisthide
+			Assert.AreEqual("John M. Martelle, Fine Pastry Magazine", author); // gisthide
 		}
 
 		[Test ()]
@@ -149,7 +149,7 @@ namespace prismic.tests
 			// Accessing number fields
 			double price = doc.GetNumber("product.price", new CultureInfo("en-US")).Value;
 			// endgist
-			Assert.AreEqual(price, 2.5);
+            Assert.AreEqual(2.5, price);
 		}
 
         [Test()]
@@ -163,8 +163,8 @@ namespace prismic.tests
             var doc = response.Results[0];
             
             decimal price = doc.GetDecimal("product.price", new CultureInfo("en-US")).Value;
-            
-            Assert.AreEqual(price, 2.5);
+
+            Assert.AreEqual(2.5, price);
         }
 
 		[Test ()]
@@ -181,7 +181,7 @@ namespace prismic.tests
 			fragments.Image.View imageView = doc.GetImageView("product.image", "main");
 			String url = imageView.Url;
 			// endgist
-			Assert.AreEqual(url, "https://lesbonneschoses.cdn.prismic.io/lesbonneschoses/f606ad513fcc2a73b909817119b84d6fd0d61a6d.png");
+            Assert.AreEqual("https://lesbonneschoses.cdn.prismic.io/lesbonneschoses/f606ad513fcc2a73b909817119b84d6fd0d61a6d.png", url);
 		}
 
 		[Test ()]
@@ -221,7 +221,7 @@ namespace prismic.tests
 				int updateHour = updateTime.Value.Hour;
 			}
 			// endgist
-			Assert.AreEqual(dateYear, 2013);
+            Assert.AreEqual(2013, dateYear);
 		}
 
 		[Test ()]
@@ -244,7 +244,7 @@ namespace prismic.tests
 			}
 			// endgist
 			var firstDesc = group.GroupDocs [0].GetStructuredText ("desc");
-			Assert.AreEqual(firstDesc.AsHtml(resolver), "<p>A detailed step by step point of view on how installing happens.</p>");
+            Assert.AreEqual("<p>A detailed step by step point of view on how installing happens.</p>", firstDesc.AsHtml(resolver));
 		}
 
 		[Test ()]
@@ -299,7 +299,7 @@ namespace prismic.tests
 			fragments.GeoPoint place = document.GetGeoPoint("article.location");
             var coordinates = place.Latitude.ToString(new CultureInfo("en-US")) + "," + place.Longitude.ToString(new CultureInfo("en-US"));
 			// endgist
-			Assert.AreEqual(coordinates, "48.877108,2.333879");
+            Assert.AreEqual("48.877108,2.333879", coordinates);
 		}
 
 		[Test ()]

--- a/src/prismic.tests/DocTest.cs
+++ b/src/prismic.tests/DocTest.cs
@@ -9,148 +9,162 @@ using Newtonsoft.Json.Linq;
 
 namespace prismic.tests
 {
-	[TestFixture ()]
-	public class DocTest
-	{
-		[Test ()]
-		public async Task ApiTest ()
-		{
-			// startgist:c023234afbc20303f792:prismic-api.cs
-			// Fetching the API is an asynchronous process
-			Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
-			// endgist
-			Assert.IsNotNull (api);
-		}
+    [TestFixture()]
+    public class DocTest
+    {
+        [Test()]
+        public async Task ApiTest()
+        {
+            // startgist:c023234afbc20303f792:prismic-api.cs
+            // Fetching the API is an asynchronous process
+            Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            // endgist
+            Assert.IsNotNull(api);
+        }
 
-		[Test ()]
-		[ExpectedException(typeof(AggregateException))]
+        [Test()]
+        [ExpectedException(typeof(AggregateException))]
         public void PrivateApiTest()
-		{
-			// startgist:a6f1067b28cc9dca7a82:prismic-apiPrivate.cs
-			// This will fail because the token is invalid, but this is how to access a private API
-			Api api = prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api", "MC5-XXXXXXX-vRfvv70").Result;
-			// endgist
-		}
+        {
+            // startgist:a6f1067b28cc9dca7a82:prismic-apiPrivate.cs
+            // This will fail because the token is invalid, but this is how to access a private API
+            Api api = prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api", "MC5-XXXXXXX-vRfvv70").Result;
+            // endgist
+        }
 
-		[Test ()]
-		public async Task ReferencesTest ()
-		{
-			// startgist:7b8defb1e1057ad27494:prismic-references.cs
-			var previewToken = "MC5VbDdXQmtuTTB6Z0hNWHF3.c--_vVbvv73vv73vv73vv71EA--_vS_vv73vv70T77-9Ke-_ve-_vWfvv70ebO-_ve-_ve-_vQN377-9ce-_vRfvv70";
-			Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api", previewToken);
-			Console.WriteLine ("API OK");
-			var stPatrickRef = api.Ref("St-Patrick specials");
-			Console.WriteLine ("StPar = " + stPatrickRef);
-			// Now we'll use this reference for all our calls
-			Response response = await api.Form("everything")
-				.Ref(stPatrickRef)
-				.Query (@"[[:d = at(document.type, ""product"")]]")
-				.Submit();
-			// The documents object contains a Response object with all documents of type "product"
-			// including the new "Saint-Patrick's Cupcake"
-			// endgist
-			Assert.AreEqual(17, response.Results.Count());
-		}
+        [Test()]
+        public async Task ReferencesTest()
+        {
+            // startgist:7b8defb1e1057ad27494:prismic-references.cs
+            var previewToken = "MC5VbDdXQmtuTTB6Z0hNWHF3.c--_vVbvv73vv73vv73vv71EA--_vS_vv73vv70T77-9Ke-_ve-_vWfvv70ebO-_ve-_ve-_vQN377-9ce-_vRfvv70";
+            Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api", previewToken);
+            Console.WriteLine("API OK");
+            var stPatrickRef = api.Ref("St-Patrick specials");
+            Console.WriteLine("StPar = " + stPatrickRef);
+            // Now we'll use this reference for all our calls
+            Response response = await api.Form("everything")
+                .Ref(stPatrickRef)
+                .Query(@"[[:d = at(document.type, ""product"")]]")
+                .Submit();
+            // The documents object contains a Response object with all documents of type "product"
+            // including the new "Saint-Patrick's Cupcake"
+            // endgist
+            Assert.AreEqual(17, response.Results.Count());
+        }
 
-		[Test ()]
-		public async Task SimpleQueryTest ()
-		{
-			// startgist:6b01f5bd50568045f9a0:prismic-simplequery.cs
-			Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
-			// Just like Api.Get, fetching a Response is asynchronous
-			Response response = await api
-				.Form("everything")
-				.Ref(api.Master)
-				.Query (@"[[:d = at(document.type, ""product"")]]")
-				.Submit();
-			// The response object contains all documents of type "product", paginated
-			// endgist
-			Assert.AreEqual (16, response.Results.Count());
-		}
+        [Test()]
+        public async Task SimpleQueryTest()
+        {
+            // startgist:6b01f5bd50568045f9a0:prismic-simplequery.cs
+            Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            // Just like Api.Get, fetching a Response is asynchronous
+            Response response = await api
+                .Form("everything")
+                .Ref(api.Master)
+                .Query(@"[[:d = at(document.type, ""product"")]]")
+                .Submit();
+            // The response object contains all documents of type "product", paginated
+            // endgist
+            Assert.AreEqual(16, response.Results.Count());
+        }
 
-		[Test ()]
-		public async Task OrderingsTest ()
-		{
-			// startgist:6437bcf0207f170dace9:prismic-orderings.cs
-			Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
-			var response = await api.Form("everything")
-				.Ref(api.Master)
-				.Query (@"[[:d = at(document.type, ""product"")]]")
-				.PageSize(100)
-				.Orderings("[my.product.price desc]")
-				.Submit();
-			// The products are now ordered by price, highest first
-			var results = response.Results;
-			// endgist
-			Assert.AreEqual(100, response.ResultsPerPage);
-		}
+        [Test()]
+        public async Task OrderingsTest()
+        {
+            // startgist:6437bcf0207f170dace9:prismic-orderings.cs
+            Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            var response = await api.Form("everything")
+                .Ref(api.Master)
+                .Query(@"[[:d = at(document.type, ""product"")]]")
+                .PageSize(100)
+                .Orderings("[my.product.price desc]")
+                .Submit();
+            // The products are now ordered by price, highest first
+            var results = response.Results;
+            // endgist
+            Assert.AreEqual(100, response.ResultsPerPage);
+        }
 
-		[Test ()]
-		public async Task PredicatesTest ()
-		{
-			// startgist:dbd1a1f4056ae7bf9959:prismic-predicates.cs
-			Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
-			var response = await api
-				.Form("everything")
-				.Ref(api.Master)
-				.Query (Predicates.at("document.type", "blog-post"), Predicates.dateAfter("my.blog-post.date", DateTime.Now))
-				.Submit();
-			// endgist
-			Assert.AreEqual (0, response.Results.Count());
-		}
+        [Test()]
+        public async Task PredicatesTest()
+        {
+            // startgist:dbd1a1f4056ae7bf9959:prismic-predicates.cs
+            Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            var response = await api
+                .Form("everything")
+                .Ref(api.Master)
+                .Query(Predicates.at("document.type", "blog-post"), Predicates.dateAfter("my.blog-post.date", DateTime.Now))
+                .Submit();
+            // endgist
+            Assert.AreEqual(0, response.Results.Count());
+        }
 
-		[Test ()]
-		public void AllPredicatesTest ()
-		{
-			// startgist:26e651e93de58bdf7165:prismic-allPredicates.cs
-			// "at" predicate: equality of a fragment to a value.
-			var at = Predicates.at("document.type", "article");
-			// "any" predicate: equality of a fragment to a value.
-			var any = Predicates.any("document.type", new string[] {"article", "blog-post"});
+        [Test()]
+        public void AllPredicatesTest()
+        {
+            // startgist:26e651e93de58bdf7165:prismic-allPredicates.cs
+            // "at" predicate: equality of a fragment to a value.
+            var at = Predicates.at("document.type", "article");
+            // "any" predicate: equality of a fragment to a value.
+            var any = Predicates.any("document.type", new string[] { "article", "blog-post" });
 
-			// "fulltext" predicate: fulltext search in a fragment.
-			var fulltext = Predicates.fulltext("my.article.body", "sausage");
+            // "fulltext" predicate: fulltext search in a fragment.
+            var fulltext = Predicates.fulltext("my.article.body", "sausage");
 
-			// "similar" predicate, with a document id as reference
-			var similar = Predicates.similar("UXasdFwe42D", 10);
-			// endgist
-		}
+            // "similar" predicate, with a document id as reference
+            var similar = Predicates.similar("UXasdFwe42D", 10);
+            // endgist
+        }
 
-		[Test ()]
-		public async Task GetTextTest ()
-		{
-			Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
-			var response = await api.Form("everything")
-				.Ref(api.Master)
-				.Query (@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbl"")]]")
-				.Submit();
-			var doc = response.Results[0];
-			// startgist:7869828eaa8c1b8555d3:prismic-getText.cs
-			var author = doc.GetText("blog-post.author");
-			// endgist
-			Assert.AreEqual("John M. Martelle, Fine Pastry Magazine", author); // gisthide
-		}
+        [Test()]
+        public async Task GetTextTest()
+        {
+            Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            var response = await api.Form("everything")
+                .Ref(api.Master)
+                .Query(@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbl"")]]")
+                .Submit();
+            var doc = response.Results[0];
+            // startgist:7869828eaa8c1b8555d3:prismic-getText.cs
+            var author = doc.GetText("blog-post.author");
+            // endgist
+            Assert.AreEqual("John M. Martelle, Fine Pastry Magazine", author); // gisthide
+        }
 
-		[Test ()]
-		public async Task GetNumberTest()
-		{
-			Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
-			var response = await api.Form("everything")
-				.Ref(api.Master)
-				.Query (@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbO"")]]")
-				.Submit();
-			var doc = response.Results[0];
-			// startgist:57e8cda4c83cadf7f7d0:prismic-getNumber.cs
-			// Number predicates
-			var gt = Predicates.gt("my.product.price", 10);
-			var lt = Predicates.lt("my.product.price", 20);
-			var inRange = Predicates.inRange("my.product.price", 10, 20);
+        [Test()]
+        public async Task GetNumberTest()
+        {
+            Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            var response = await api.Form("everything")
+                .Ref(api.Master)
+                .Query(@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbO"")]]")
+                .Submit();
+            var doc = response.Results[0];
+            // startgist:57e8cda4c83cadf7f7d0:prismic-getNumber.cs
+            // Number predicates
+            var gt = Predicates.gt("my.product.price", 10);
+            var lt = Predicates.lt("my.product.price", 20);
+            var inRange = Predicates.inRange("my.product.price", 10, 20);
 
-			// Accessing number fields
-			double price = doc.GetNumber("product.price", new CultureInfo("en-US")).Value;
-			// endgist
+            // Accessing number fields
+            double price = doc.GetNumber("product.price", new CultureInfo("en-US")).Value;
+            // endgist
             Assert.AreEqual(2.5, price);
-		}
+        }
+
+        [Test()]
+        public async Task GetNumberNullTest()
+        {
+            Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            var response = await api.Form("everything")
+                .Ref(api.Master)
+                .Query(@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbO"")]]")
+                .Submit();
+            var doc = response.Results[0];
+
+            var price = doc.GetNumber("product.price_null", new CultureInfo("en-US"));
+            Assert.IsNull(price);
+        }
 
         [Test()]
         public async Task GetDecimalTest()
@@ -161,218 +175,244 @@ namespace prismic.tests
                 .Query(@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbO"")]]")
                 .Submit();
             var doc = response.Results[0];
-            
+
             decimal price = doc.GetDecimal("product.price", new CultureInfo("en-US")).Value;
 
             Assert.AreEqual(2.5, price);
         }
 
-		[Test ()]
-		public async Task ImagesTest()
-		{
-			Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
-			var response = await api.Form("everything")
-				.Ref(api.Master)
-				.Query (@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbO"")]]")
-				.Submit();
-			var doc = response.Results[0];
-			// startgist:2ba6c72a80cf9d2af15e:prismic-images.cs
-			// Accessing image fields
-			fragments.Image.View imageView = doc.GetImageView("product.image", "main");
-			String url = imageView.Url;
-			// endgist
+        [Test()]
+        public async Task GetDecimalNullTest()
+        {
+            Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            var response = await api.Form("everything")
+                .Ref(api.Master)
+                .Query(@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbO"")]]")
+                .Submit();
+            var doc = response.Results[0];
+
+            var price = doc.GetDecimal("product.price_null", new CultureInfo("en-US"));
+
+            Assert.IsNull(price);
+        }
+
+        [Test()]
+        public async Task ImagesTest()
+        {
+            Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            var response = await api.Form("everything")
+                .Ref(api.Master)
+                .Query(@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbO"")]]")
+                .Submit();
+            var doc = response.Results[0];
+            // startgist:2ba6c72a80cf9d2af15e:prismic-images.cs
+            // Accessing image fields
+            fragments.Image.View imageView = doc.GetImageView("product.image", "main");
+            String url = imageView.Url;
+            // endgist
             Assert.AreEqual("https://lesbonneschoses.cdn.prismic.io/lesbonneschoses/f606ad513fcc2a73b909817119b84d6fd0d61a6d.png", url);
-		}
+        }
 
-		[Test ()]
-		public async Task DateTimestampTest()
-		{
-			Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
-			Console.WriteLine ("DateTimestampTest, got API " + api);
-			var response = await api.Form("everything")
-				.Ref(api.Master)
-				.Query (@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbl"")]]")
-				.Submit();
-			var doc = response.Results[0];
-			// startgist:653bcba6211a9b71429d:prismic-dateTimestamp.cs
-			// Date and Timestamp predicates
-			var dateBefore = Predicates.dateBefore("my.product.releaseDate", new DateTime(2014, 6, 1));
-			var dateAfter = Predicates.dateAfter("my.product.releaseDate", new DateTime(2014, 1, 1));
-			var dateBetween = Predicates.dateBetween("my.product.releaseDate", new DateTime(2014, 1, 1), new DateTime(2014, 6, 1));
-			var dayOfMonth = Predicates.dayOfMonth("my.product.releaseDate", 14);
-			var dayOfMonthAfter = Predicates.dayOfMonthAfter("my.product.releaseDate", 14);
-			var dayOfMonthBefore = Predicates.dayOfMonthBefore("my.product.releaseDate", 14);
-			var dayOfWeek = Predicates.dayOfWeek("my.product.releaseDate", DayOfWeek.Tuesday);
-			var dayOfWeekAfter = Predicates.dayOfWeekAfter("my.product.releaseDate", DayOfWeek.Wednesday);
-			var dayOfWeekBefore = Predicates.dayOfWeekBefore("my.product.releaseDate", DayOfWeek.Wednesday);
-			var month = Predicates.month("my.product.releaseDate", Predicates.Month.June);
-			var monthBefore = Predicates.monthBefore("my.product.releaseDate", Predicates.Month.June);
-			var monthAfter = Predicates.monthAfter("my.product.releaseDate", Predicates.Month.June);
-			var year = Predicates.year("my.product.releaseDate", 2014);
-			var hour = Predicates.hour("my.product.releaseDate", 12);
-			var hourBefore = Predicates.hourBefore("my.product.releaseDate", 12);
-			var hourAfter = Predicates.hourAfter("my.product.releaseDate", 12);
+        [Test()]
+        public async Task DateTimestampTest()
+        {
+            Api api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            Console.WriteLine("DateTimestampTest, got API " + api);
+            var response = await api.Form("everything")
+                .Ref(api.Master)
+                .Query(@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbl"")]]")
+                .Submit();
+            var doc = response.Results[0];
+            // startgist:653bcba6211a9b71429d:prismic-dateTimestamp.cs
+            // Date and Timestamp predicates
+            var dateBefore = Predicates.dateBefore("my.product.releaseDate", new DateTime(2014, 6, 1));
+            var dateAfter = Predicates.dateAfter("my.product.releaseDate", new DateTime(2014, 1, 1));
+            var dateBetween = Predicates.dateBetween("my.product.releaseDate", new DateTime(2014, 1, 1), new DateTime(2014, 6, 1));
+            var dayOfMonth = Predicates.dayOfMonth("my.product.releaseDate", 14);
+            var dayOfMonthAfter = Predicates.dayOfMonthAfter("my.product.releaseDate", 14);
+            var dayOfMonthBefore = Predicates.dayOfMonthBefore("my.product.releaseDate", 14);
+            var dayOfWeek = Predicates.dayOfWeek("my.product.releaseDate", DayOfWeek.Tuesday);
+            var dayOfWeekAfter = Predicates.dayOfWeekAfter("my.product.releaseDate", DayOfWeek.Wednesday);
+            var dayOfWeekBefore = Predicates.dayOfWeekBefore("my.product.releaseDate", DayOfWeek.Wednesday);
+            var month = Predicates.month("my.product.releaseDate", Predicates.Month.June);
+            var monthBefore = Predicates.monthBefore("my.product.releaseDate", Predicates.Month.June);
+            var monthAfter = Predicates.monthAfter("my.product.releaseDate", Predicates.Month.June);
+            var year = Predicates.year("my.product.releaseDate", 2014);
+            var hour = Predicates.hour("my.product.releaseDate", 12);
+            var hourBefore = Predicates.hourBefore("my.product.releaseDate", 12);
+            var hourAfter = Predicates.hourAfter("my.product.releaseDate", 12);
 
-			// Accessing Date and Timestamp fields
-			DateTime date = doc.GetDate("blog-post.date").Value;
-			int dateYear = date.Year;
-			fragments.Timestamp updateTime = doc.GetTimestamp("blog-post.update");
-			if (updateTime != null) {
-				int updateHour = updateTime.Value.Hour;
-			}
-			// endgist
+            // Accessing Date and Timestamp fields
+            DateTime date = doc.GetDate("blog-post.date").Value;
+            int dateYear = date.Year;
+            fragments.Timestamp updateTime = doc.GetTimestamp("blog-post.update");
+            if (updateTime != null)
+            {
+                int updateHour = updateTime.Value.Hour;
+            }
+            // endgist
             Assert.AreEqual(2013, dateYear);
-		}
+        }
 
-		[Test ()]
-		public void GroupTest()
-		{
-			var resolver =
-				prismic.DocumentLinkResolver.For (l => String.Format ("http://localhost/{0}/{1}", l.Type, l.Id));
+        [Test()]
+        public void GroupTest()
+        {
+            var resolver =
+                prismic.DocumentLinkResolver.For(l => String.Format("http://localhost/{0}/{1}", l.Type, l.Id));
 
-			var json = "{\"id\":\"abcd\",\"type\":\"article\",\"href\":\"\",\"slugs\":[],\"tags\":[],\"data\":{\"article\":{\"documents\":{\"type\":\"Group\",\"value\":[{\"linktodoc\":{\"type\":\"Link.document\",\"value\":{\"document\":{\"id\":\"UrDejAEAAFwMyrW9\",\"type\":\"doc\",\"tags\":[],\"slug\":\"installing-meta-micro\"},\"isBroken\":false}},\"desc\":{\"type\":\"StructuredText\",\"value\":[{\"type\":\"paragraph\",\"text\":\"A detailed step by step point of view on how installing happens.\",\"spans\":[]}]}},{\"linktodoc\":{\"type\":\"Link.document\",\"value\":{\"document\":{\"id\":\"UrDmKgEAALwMyrXA\",\"type\":\"doc\",\"tags\":[],\"slug\":\"using-meta-micro\"},\"isBroken\":false}}}]}}}}";
-			var document = Document.Parse(JObject.Parse(json));
-			// startgist:b5b40c40a696911081d7:prismic-group.cs
-			var group = document.GetGroup("article.documents");
-			foreach (GroupDoc doc in group.GroupDocs) {
-				try {
-					fragments.StructuredText desc = doc.GetStructuredText("desc");
-					fragments.Link link = doc.GetLink("linktodoc");
-				} catch (Exception e) {
-					// Missing key
-				}
-			}
-			// endgist
-			var firstDesc = group.GroupDocs [0].GetStructuredText ("desc");
+            var json = "{\"id\":\"abcd\",\"type\":\"article\",\"href\":\"\",\"slugs\":[],\"tags\":[],\"data\":{\"article\":{\"documents\":{\"type\":\"Group\",\"value\":[{\"linktodoc\":{\"type\":\"Link.document\",\"value\":{\"document\":{\"id\":\"UrDejAEAAFwMyrW9\",\"type\":\"doc\",\"tags\":[],\"slug\":\"installing-meta-micro\"},\"isBroken\":false}},\"desc\":{\"type\":\"StructuredText\",\"value\":[{\"type\":\"paragraph\",\"text\":\"A detailed step by step point of view on how installing happens.\",\"spans\":[]}]}},{\"linktodoc\":{\"type\":\"Link.document\",\"value\":{\"document\":{\"id\":\"UrDmKgEAALwMyrXA\",\"type\":\"doc\",\"tags\":[],\"slug\":\"using-meta-micro\"},\"isBroken\":false}}}]}}}}";
+            var document = Document.Parse(JObject.Parse(json));
+            // startgist:b5b40c40a696911081d7:prismic-group.cs
+            var group = document.GetGroup("article.documents");
+            foreach (GroupDoc doc in group.GroupDocs)
+            {
+                try
+                {
+                    fragments.StructuredText desc = doc.GetStructuredText("desc");
+                    fragments.Link link = doc.GetLink("linktodoc");
+                }
+                catch (Exception e)
+                {
+                    // Missing key
+                }
+            }
+            // endgist
+            var firstDesc = group.GroupDocs[0].GetStructuredText("desc");
             Assert.AreEqual("<p>A detailed step by step point of view on how installing happens.</p>", firstDesc.AsHtml(resolver));
-		}
+        }
 
-		[Test ()]
-		public void LinkTest()
-		{
-			var json = "{\"id\":\"abcd\",\"type\":\"article\",\"href\":\"\",\"slugs\":[],\"tags\":[],\"data\":{\"article\":{\"source\":{\"type\":\"Link.document\",\"value\":{\"document\":{\"id\":\"UlfoxUnM0wkXYXbE\",\"type\":\"product\",\"tags\":[\"Macaron\"],\"slug\":\"dark-chocolate-macaron\"},\"isBroken\":false}}}}}";
-			var document = Document.Parse(JObject.Parse(json));
-			// startgist:f439d465a87cbddb2737:prismic-link.cs
-			var resolver =
-				prismic.DocumentLinkResolver.For (l => String.Format ("http://localhost/{0}/{1}", l.Id, l.Slug));
-			var source = document.GetLink("article.source");
-			var url = source.GetUrl(resolver);
-			// endgist
-			Assert.AreEqual("http://localhost/UlfoxUnM0wkXYXbE/dark-chocolate-macaron", url);
-		}
+        [Test()]
+        public void LinkTest()
+        {
+            var json = "{\"id\":\"abcd\",\"type\":\"article\",\"href\":\"\",\"slugs\":[],\"tags\":[],\"data\":{\"article\":{\"source\":{\"type\":\"Link.document\",\"value\":{\"document\":{\"id\":\"UlfoxUnM0wkXYXbE\",\"type\":\"product\",\"tags\":[\"Macaron\"],\"slug\":\"dark-chocolate-macaron\"},\"isBroken\":false}}}}}";
+            var document = Document.Parse(JObject.Parse(json));
+            // startgist:f439d465a87cbddb2737:prismic-link.cs
+            var resolver =
+                prismic.DocumentLinkResolver.For(l => String.Format("http://localhost/{0}/{1}", l.Id, l.Slug));
+            var source = document.GetLink("article.source");
+            var url = source.GetUrl(resolver);
+            // endgist
+            Assert.AreEqual("http://localhost/UlfoxUnM0wkXYXbE/dark-chocolate-macaron", url);
+        }
 
-		[Test ()]
-		public void EmbedTest()
-		{
-			var json = "{\"id\":\"abcd\",\"type\":\"article\",\"href\":\"\",\"slugs\":[],\"tags\":[],\"data\":{\"article\":{\"video\":{\"type\":\"Embed\",\"value\":{\"oembed\":{\"provider_url\":\"http://www.youtube.com/\",\"type\":\"video\",\"thumbnail_height\":360,\"height\":270,\"thumbnail_url\":\"http://i1.ytimg.com/vi/baGfM6dBzs8/hqdefault.jpg\",\"width\":480,\"provider_name\":\"YouTube\",\"html\":\"<iframe width=\\\"480\\\" height=\\\"270\\\" src=\\\"http://www.youtube.com/embed/baGfM6dBzs8?feature=oembed\\\" frameborder=\\\"0\\\" allowfullscreen></iframe>\",\"author_name\":\"Siobhan Wilson\",\"version\":\"1.0\",\"author_url\":\"http://www.youtube.com/user/siobhanwilsonsongs\",\"thumbnail_width\":480,\"title\":\"Siobhan Wilson - All Dressed Up\",\"embed_url\":\"https://www.youtube.com/watch?v=baGfM6dBzs8\"}}}}}}";
-			var document = Document.Parse(JObject.Parse(json));
-			// startgist:a0a1846d443b2fa39097:prismic-embed.cs
-			var video = document.GetEmbed ("article.video");
-			// Html is the code to include to embed the object, and depends on the embedded service
-			var html = video.Html;
-			// endgist
-			Assert.AreEqual("<iframe width=\"480\" height=\"270\" src=\"http://www.youtube.com/embed/baGfM6dBzs8?feature=oembed\" frameborder=\"0\" allowfullscreen></iframe>", html);
-		}
+        [Test()]
+        public void EmbedTest()
+        {
+            var json = "{\"id\":\"abcd\",\"type\":\"article\",\"href\":\"\",\"slugs\":[],\"tags\":[],\"data\":{\"article\":{\"video\":{\"type\":\"Embed\",\"value\":{\"oembed\":{\"provider_url\":\"http://www.youtube.com/\",\"type\":\"video\",\"thumbnail_height\":360,\"height\":270,\"thumbnail_url\":\"http://i1.ytimg.com/vi/baGfM6dBzs8/hqdefault.jpg\",\"width\":480,\"provider_name\":\"YouTube\",\"html\":\"<iframe width=\\\"480\\\" height=\\\"270\\\" src=\\\"http://www.youtube.com/embed/baGfM6dBzs8?feature=oembed\\\" frameborder=\\\"0\\\" allowfullscreen></iframe>\",\"author_name\":\"Siobhan Wilson\",\"version\":\"1.0\",\"author_url\":\"http://www.youtube.com/user/siobhanwilsonsongs\",\"thumbnail_width\":480,\"title\":\"Siobhan Wilson - All Dressed Up\",\"embed_url\":\"https://www.youtube.com/watch?v=baGfM6dBzs8\"}}}}}}";
+            var document = Document.Parse(JObject.Parse(json));
+            // startgist:a0a1846d443b2fa39097:prismic-embed.cs
+            var video = document.GetEmbed("article.video");
+            // Html is the code to include to embed the object, and depends on the embedded service
+            var html = video.Html;
+            // endgist
+            Assert.AreEqual("<iframe width=\"480\" height=\"270\" src=\"http://www.youtube.com/embed/baGfM6dBzs8?feature=oembed\" frameborder=\"0\" allowfullscreen></iframe>", html);
+        }
 
-		[Test()]
-		public void ColorTest()
-		{
-			var json = "{\"id\":\"abcd\",\"type\":\"article\",\"href\":\"\",\"slugs\":[],\"tags\":[],\"data\":{\"article\":{\"background\":{\"type\":\"Color\",\"value\":\"#000000\"}}}}";
-			var document = Document.Parse(JObject.Parse(json));
-			// startgist:0d0fa9849ae5ff7c921c:prismic-color.cs
-			var bgcolor = document.GetColor("article.background");
-			var hex = bgcolor.Hex;
-			// endgist
-			Assert.AreEqual("#000000", hex);
-		}
+        [Test()]
+        public void ColorTest()
+        {
+            var json = "{\"id\":\"abcd\",\"type\":\"article\",\"href\":\"\",\"slugs\":[],\"tags\":[],\"data\":{\"article\":{\"background\":{\"type\":\"Color\",\"value\":\"#000000\"}}}}";
+            var document = Document.Parse(JObject.Parse(json));
+            // startgist:0d0fa9849ae5ff7c921c:prismic-color.cs
+            var bgcolor = document.GetColor("article.background");
+            var hex = bgcolor.Hex;
+            // endgist
+            Assert.AreEqual("#000000", hex);
+        }
 
-		[Test()]
-		public void GeopointTest()
-		{
-			var json = "{\"id\":\"abcd\",\"type\":\"article\",\"href\":\"\",\"slugs\":[],\"tags\":[],\"data\":{\"article\":{\"location\":{\"type\":\"GeoPoint\",\"value\":{\"latitude\":48.877108,\"longitude\":2.333879}}}}}";
-			var document = Document.Parse(JObject.Parse(json));
-			// startgist:ffd5197f8b1f3c9b302c:prismic-geopoint.cs
-			// "near" predicate for GeoPoint fragments
-			var near = "[[:d = geopoint.near(my.store.location, 48.8768767, 2.3338802, 10)]]";
+        [Test()]
+        public void GeopointTest()
+        {
+            var json = "{\"id\":\"abcd\",\"type\":\"article\",\"href\":\"\",\"slugs\":[],\"tags\":[],\"data\":{\"article\":{\"location\":{\"type\":\"GeoPoint\",\"value\":{\"latitude\":48.877108,\"longitude\":2.333879}}}}}";
+            var document = Document.Parse(JObject.Parse(json));
+            // startgist:ffd5197f8b1f3c9b302c:prismic-geopoint.cs
+            // "near" predicate for GeoPoint fragments
+            var near = "[[:d = geopoint.near(my.store.location, 48.8768767, 2.3338802, 10)]]";
 
-			// Accessing GeoPoint fragments
-			fragments.GeoPoint place = document.GetGeoPoint("article.location");
+            // Accessing GeoPoint fragments
+            fragments.GeoPoint place = document.GetGeoPoint("article.location");
             var coordinates = place.Latitude.ToString(new CultureInfo("en-US")) + "," + place.Longitude.ToString(new CultureInfo("en-US"));
-			// endgist
+            // endgist
             Assert.AreEqual("48.877108,2.333879", coordinates);
-		}
+        }
 
-		[Test ()]
-		public async Task AsHtmlTest ()
-		{
-			var api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
-			var response = await api
-				.Form("everything")
-				.Ref(api.Master)
-				.Query (@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbX"")]]")
-				.Submit();
-			// startgist:097067bd2495233520bb:prismic-asHtml.cs
-			var document = response.Results.First ();
-			var resolver =
-				prismic.DocumentLinkResolver.For (l => String.Format ("http://localhost/{0}/{1}", l.Type, l.Id));
-			var html = document.GetStructuredText ("blog-post.body").AsHtml(resolver);
-			// endgist
-			Assert.IsNotNull (html);
-		}
+        [Test()]
+        public async Task AsHtmlTest()
+        {
+            var api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            var response = await api
+                .Form("everything")
+                .Ref(api.Master)
+                .Query(@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbX"")]]")
+                .Submit();
+            // startgist:097067bd2495233520bb:prismic-asHtml.cs
+            var document = response.Results.First();
+            var resolver =
+                prismic.DocumentLinkResolver.For(l => String.Format("http://localhost/{0}/{1}", l.Type, l.Id));
+            var html = document.GetStructuredText("blog-post.body").AsHtml(resolver);
+            // endgist
+            Assert.IsNotNull(html);
+        }
 
-		[Test ()]
-		public async Task HtmlSerializerTest ()
-		{
-			var api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
-			var response = await api
-				.Form("everything")
-				.Ref(api.Master)
-				.Query (@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbX"")]]")
-				.Submit();
-			// startgist:b5f2de0fb813b52a14a9:prismic-htmlSerializer.cs
-			var document = response.Results.First ();
-			var resolver =
-				prismic.DocumentLinkResolver.For (l => String.Format ("http://localhost/{0}/{1}", l.Type, l.Id));
-			var serializer = prismic.HtmlSerializer.For ((elt, body) => {
-				if (elt is fragments.StructuredText.Hyperlink) {
-					var link = ((fragments.StructuredText.Hyperlink)elt).Link;
-					// Add a class to hyperlinks
-					if (link is fragments.DocumentLink) {
-						var doclink = ((fragments.DocumentLink)link);
-						return String.Format("<a class=\"some-link\" href=\"{0}\">{1}</a>", resolver.Resolve(doclink), body);
-					}
-				}
-				if (elt is fragments.StructuredText.Image) {
-					// Don't wrap images in <p> blocks
-					var imageview = ((fragments.StructuredText.Image)elt).View;
-					return imageview.AsHtml(resolver);
-				}
-				return null;
-			});
-			var html = document.GetStructuredText ("blog-post.body").AsHtml(resolver, serializer);
-			// endgist
-			Assert.IsNotNull (html);
-		}
+        [Test()]
+        public async Task HtmlSerializerTest()
+        {
+            var api = await prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api");
+            var response = await api
+                .Form("everything")
+                .Ref(api.Master)
+                .Query(@"[[:d = at(document.id, ""UlfoxUnM0wkXYXbX"")]]")
+                .Submit();
+            // startgist:b5f2de0fb813b52a14a9:prismic-htmlSerializer.cs
+            var document = response.Results.First();
+            var resolver =
+                prismic.DocumentLinkResolver.For(l => String.Format("http://localhost/{0}/{1}", l.Type, l.Id));
+            var serializer = prismic.HtmlSerializer.For((elt, body) =>
+            {
+                if (elt is fragments.StructuredText.Hyperlink)
+                {
+                    var link = ((fragments.StructuredText.Hyperlink)elt).Link;
+                    // Add a class to hyperlinks
+                    if (link is fragments.DocumentLink)
+                    {
+                        var doclink = ((fragments.DocumentLink)link);
+                        return String.Format("<a class=\"some-link\" href=\"{0}\">{1}</a>", resolver.Resolve(doclink), body);
+                    }
+                }
+                if (elt is fragments.StructuredText.Image)
+                {
+                    // Don't wrap images in <p> blocks
+                    var imageview = ((fragments.StructuredText.Image)elt).View;
+                    return imageview.AsHtml(resolver);
+                }
+                return null;
+            });
+            var html = document.GetStructuredText("blog-post.body").AsHtml(resolver, serializer);
+            // endgist
+            Assert.IsNotNull(html);
+        }
 
-		[Test()]
-		public void CacheTest()
-		{
-			// startgist:9307922348c5ce1ef34c:prismic-cache.cs
-			// TODO
-			var cache = LambdaCache.For (
-				(key, value, ttl) => {
-					return null;
-				},
-				key => {
-					return null;
-				}
-			);
-			// This Api will use the custom cache object
-			var api = prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api", cache);
-			// endgist
-		}
+        [Test()]
+        public void CacheTest()
+        {
+            // startgist:9307922348c5ce1ef34c:prismic-cache.cs
+            // TODO
+            var cache = LambdaCache.For(
+                (key, value, ttl) =>
+                {
+                    return null;
+                },
+                key =>
+                {
+                    return null;
+                }
+            );
+            // This Api will use the custom cache object
+            var api = prismic.Api.Get("https://lesbonneschoses.cdn.prismic.io/api", cache);
+            // endgist
+        }
 
-	}
+    }
 
 
 }

--- a/src/prismic/Fragment.cs
+++ b/src/prismic/Fragment.cs
@@ -51,9 +51,9 @@ namespace prismic
 				return new Number (Double.Parse ((string)json));
 			}
 
-            public static Number Parse(string json)
+            public static Number Parse(string json, IFormatProvider format)
             {
-                return new Number(Double.Parse(json));
+                return new Number(Double.Parse(json, format));
             }
 		}
 

--- a/src/prismic/Fragment.cs
+++ b/src/prismic/Fragment.cs
@@ -50,7 +50,37 @@ namespace prismic
 			public static Number Parse(JToken json) {
 				return new Number (Double.Parse ((string)json));
 			}
+
+            public static Number Parse(string json)
+            {
+                return new Number(Double.Parse(json));
+            }
 		}
+
+        public class Decimal : Fragment
+        {
+            private readonly decimal value;
+            public decimal Value
+            {
+                get
+                {
+                    return value;
+                }
+            }
+            public Decimal(decimal value)
+            {
+                this.value = value;
+            }
+            public String AsHtml()
+            {
+                return ("<span class=\"number\">" + value + "</span>");
+            }
+            public static Decimal Parse(string value, IFormatProvider provider)
+            {
+                var v = Convert.ToDecimal(value, provider);
+                return new Decimal(v);
+            }
+        }
 
 		public class Image: Fragment {
 
@@ -591,7 +621,7 @@ namespace prismic
 				case "Timestamp":
 					return Timestamp.Parse (json);
 				case "Number":
-					return Number.Parse (json);
+					return Text.Parse (json);
 				case "Color":
 					return Color.Parse (json);
 				case "Embed":

--- a/src/prismic/Predicates.cs
+++ b/src/prismic/Predicates.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Web.Routing;
 
 namespace prismic
 {
@@ -60,7 +62,11 @@ namespace prismic
 			} else if (value is System.DayOfWeek) {
 				return ("\"" + capitalize(((System.DayOfWeek) value).ToString()) + "\"");
 			} else if (value is DateTime) {
-				return (((DateTime) value) - new DateTime(1970, 1, 1)).TotalMilliseconds.ToString();
+				return (((DateTime) value) - new DateTime(1970, 1, 1)).TotalMilliseconds.ToString(new CultureInfo("en-US"));
+            } else if (value is Double) {
+				return ((double)value).ToString(new CultureInfo("en-US"));
+            } else if (value is Decimal) {
+				return ((decimal)value).ToString(new CultureInfo("en-US"));
 			} else {
 				return value.ToString();
 			}

--- a/src/prismic/WithFragments.cs
+++ b/src/prismic/WithFragments.cs
@@ -71,12 +71,16 @@ namespace prismic
             return null;
 		}
 
-		public fragments.Number GetNumber(String field) {
-			var frag = Get (field) as Text;
-		    return Number.Parse(frag.Value);
+        public fragments.Number GetNumber(String field, IFormatProvider format = null)
+        {
+            if (format == null)
+                format = Thread.CurrentThread.CurrentCulture;
+            
+            var frag = Get (field) as Text;
+		    return Number.Parse(frag.Value, format);
 		}
 
-        public fragments.Decimal GetDecimal(String field, IFormatProvider format)
+        public fragments.Decimal GetDecimal(String field, IFormatProvider format = null)
         {
             if (format == null)
                 format = Thread.CurrentThread.CurrentCulture;

--- a/src/prismic/WithFragments.cs
+++ b/src/prismic/WithFragments.cs
@@ -77,6 +77,10 @@ namespace prismic
                 format = Thread.CurrentThread.CurrentCulture;
             
             var frag = Get (field) as Text;
+
+            if (frag == null)
+                return null;
+
 		    return Number.Parse(frag.Value, format);
 		}
 
@@ -86,6 +90,10 @@ namespace prismic
                 format = Thread.CurrentThread.CurrentCulture;
             
             var frag = Get(field) as Text;
+
+            if (frag == null)
+                return null;
+
             return Decimal.Parse(frag.Value, format);
         }
 

--- a/src/prismic/WithFragments.cs
+++ b/src/prismic/WithFragments.cs
@@ -3,7 +3,10 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
 using prismic.fragments;
+using Decimal = prismic.fragments.Decimal;
 
 namespace prismic
 {
@@ -46,16 +49,16 @@ namespace prismic
 
 		public String GetText(String field) {
 			Fragment frag = Get (field);
-			if (frag is fragments.Text) {
+			
+            if (frag is fragments.Text) {
 				return ((fragments.Text)frag).Value;
 			}
-			if (frag is fragments.Number) {
-				return ((fragments.Number)frag).Value.ToString ();
-			}
-			if (frag is fragments.Color) {
+			
+            if (frag is fragments.Color) {
 				return ((fragments.Color)frag).Hex;
 			}
-			if (frag is fragments.StructuredText) {
+			
+            if (frag is fragments.StructuredText) {
 				var result = "";
 				foreach (fragments.StructuredText.Block block in ((fragments.StructuredText)frag).Blocks) {
 					if (block is fragments.StructuredText.TextBlock) {
@@ -64,16 +67,23 @@ namespace prismic
 				}
 				return result;
 			}
-			if (frag is fragments.Number) {
-				return ((fragments.Number)frag).Value.ToString ();
-			}
-			return null;
+			
+            return null;
 		}
 
 		public fragments.Number GetNumber(String field) {
-			Fragment frag = Get (field);
-			return frag is fragments.Number ? (fragments.Number)frag : null;
+			var frag = Get (field) as Text;
+		    return Number.Parse(frag.Value);
 		}
+
+        public fragments.Decimal GetDecimal(String field, IFormatProvider format)
+        {
+            if (format == null)
+                format = Thread.CurrentThread.CurrentCulture;
+            
+            var frag = Get(field) as Text;
+            return Decimal.Parse(frag.Value, format);
+        }
 
 		public fragments.Image.View GetImageView(String field, String view) {
 			var image = GetImage (field);


### PR DESCRIPTION
Hi,

I changed the way numeric values are dealt with when retrieving and parsing data from prismic API calls.

Number fragment was being converted as soon as the value came in using the current thread culture, so whenever the main thread of the application was not in a culture ta uses . (dot) as the decimal separator the numeric value became conversion was wrong. Example: when the main thread of the application is running on pt-BR 78.50 becomes 7850,00 which is wrong.

In order to fix it the original value is stored inside the fragment as text and it is converted only when the caller calls GetNumber. Now it is also possible to specify the culture (IFormatProvider) when getting the specific fragment.

I also added a new GetDecimal method to return a decimal instead of double because decimals are better suited for currency instead of doubles.

I also fixed 4 tests that were failing because they were built on the premise that tests are always ran on en-US machines which is not the case for many people.

Also updated ReleaseNotes.md with new stuff.