### PR TITLE
Changing Number fragment from Double to Decimal and fixing issues with culture

### DIFF
--- a/src/prismic.tests/DocTest.cs
+++ b/src/prismic.tests/DocTest.cs
@@ -146,7 +146,7 @@ namespace prismic.tests
 			var inRange = Predicates.inRange("my.product.price", 10, 20);
 
 			// Accessing number fields
-			double price = doc.GetNumber("product.price").Value;
+			decimal price = doc.GetNumber("product.price").Value;
 			// endgist
 			Assert.AreEqual(price, 2.5);
 		}
@@ -283,7 +283,8 @@ namespace prismic.tests
 			fragments.GeoPoint place = document.GetGeoPoint("article.location");
 			var coordinates = place.Latitude + "," + place.Longitude;
 			// endgist
-			Assert.AreEqual(coordinates, "48.877108,2.333879");
+			Assert.AreEqual(place.Latitude, 48.877108);
+            Assert.AreEqual(place.Longitude, 2.333879);
 		}
 
 		[Test ()]

--- a/src/prismic/Fragment.cs
+++ b/src/prismic/Fragment.cs
@@ -35,20 +35,27 @@ namespace prismic
 		}
 
 		public class Number: Fragment {
-			private Double value;
-			public Double Value {
+
+            private static readonly CultureInfo _defaultCultureInfo = new CultureInfo("en-US");
+			private Decimal value;
+			public Decimal Value {
 				get {
 					return value;
 				}
 			}
-			public Number(Double value) {
+			public Number(Decimal value) {
 				this.value = value;
 			}
 			public String AsHtml() {
 				return ("<span class=\"number\">" + value + "</span>");
 			}
-			public static Number Parse(JToken json) {
-				return new Number (Double.Parse ((string)json));
+			public static Number Parse(JToken json, CultureInfo ci = null)
+			{
+			    if(ci == null)
+                    ci = _defaultCultureInfo;
+
+                var v = Convert.ToDecimal((string) json, ci);
+                return new Number (v);
 			}
 		}
 
@@ -609,7 +616,9 @@ namespace prismic
 
 		public class GeoPoint: Fragment {
 			private Double latitude;
-			public Double Latitude {
+            private static readonly CultureInfo _defaultCultureInfo = new CultureInfo("en-US");
+
+            public Double Latitude {
 				get { return latitude; }
 			}
 			private Double longitude;
@@ -624,8 +633,8 @@ namespace prismic
 
 			public static GeoPoint Parse(JToken json) {
 				try {
-					Double latitude = (Double)json["latitude"];
-					Double longitude = (Double)json["longitude"];
+					Double latitude = Double.Parse((string)json["latitude"], _defaultCultureInfo);
+				    Double longitude = Double.Parse((string) json["longitude"], _defaultCultureInfo);
 					return new GeoPoint(latitude, longitude);
 				} catch(Exception) {
 					return null;

--- a/src/prismic/Predicates.cs
+++ b/src/prismic/Predicates.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace prismic
 {
@@ -11,7 +12,8 @@ namespace prismic
 
 	public class Predicate: IPredicate {
 
-		private String name;
+        private static readonly CultureInfo _defaultCultureInfo = new CultureInfo("en-US");
+        private String name;
 		private String fragment;
 		private Object value1;
 		private Object value2;
@@ -60,8 +62,17 @@ namespace prismic
 			} else if (value is System.DayOfWeek) {
 				return ("\"" + capitalize(((System.DayOfWeek) value).ToString()) + "\"");
 			} else if (value is DateTime) {
-				return (((DateTime) value) - new DateTime(1970, 1, 1)).TotalMilliseconds.ToString();
-			} else {
+				return (((DateTime) value) - new DateTime(1970, 1, 1)).TotalMilliseconds.ToString(_defaultCultureInfo);
+            }
+            else if (value is Double)
+            {
+                return ((Double)value).ToString(_defaultCultureInfo);
+            }
+            else if (value is Decimal)
+            {
+                return ((Decimal)value).ToString(_defaultCultureInfo);
+            }
+            else {
 				return value.ToString();
 			}
 		}


### PR DESCRIPTION
This pull request is a follow up on my previous request regarding the choice of Double instead of Decimal to represent non integer numbers inside the API. Decimal is much more common, widely used and precise when dealing with decimal point number such as money. As recommended I changed the Number fragment to return Decimal.

It also addresses a problem where GeoPoint, Number and Date parsing were failing and behaving in a non consistent way depending on the client's default machine CultureInfo because the API didn't use a default CultureInfo (en-US). This could cause a number to return 25 instead of 2.5 and status 400 responses in the server API when the date was not in mm-dd-yyyy format (which is pretty much all of the world except the US and a few other countries).