### PR TITLE
Logging performance issue

### DIFF
--- a/src/prismic/Form.cs
+++ b/src/prismic/Form.cs
@@ -428,7 +428,6 @@ namespace prismic
 						}
 					}
 					api.Logger.log ("DEBUG", "Fetching URL: " + url);
-					Console.WriteLine ("Fetching URL: " + url);
 					var json = await api.PrismicHttpClient.fetch (url, api.Logger, api.Cache);
 					return Response.Parse(json);
 				} else {


### PR DESCRIPTION
The main reason for this change is that Console.WriteLine is causing performance issues, resulting in very slow load times. Besides, the client already decides what kind of logger should be used by passing it when creating the API instance.

Fixes https://github.com/prismicio/csharp-kit/issues/31